### PR TITLE
do add naming to github action workflow job so that it can be used in…

### DIFF
--- a/.github/workflows/devkit_build.yml
+++ b/.github/workflows/devkit_build.yml
@@ -3,9 +3,10 @@ name: DevKit Build
 on:
     workflow_dispatch:
     pull_request:
-
+      branches: [ main ]
 jobs:
   build:
+    name: Build_DevKit
     runs-on: ubuntu-slim
     
     steps:


### PR DESCRIPTION
This pull request makes a minor update to the DevKit build workflow configuration. The workflow is now set to run only on pull requests targeting the `main` branch, and the build job has been given a more descriptive name.